### PR TITLE
Always allow Primary Owner to change permissions

### DIFF
--- a/paper/src/main/java/vg/civcraft/mc/namelayer/gui/PermissionManageGUI.java
+++ b/paper/src/main/java/vg/civcraft/mc/namelayer/gui/PermissionManageGUI.java
@@ -118,8 +118,8 @@ public class PermissionManageGUI extends AbstractGroupGUI {
 			ItemStack is = null;
 			Clickable c;
 			final boolean hasPerm = gp.hasPermission(pType, perm);
-			boolean canEdit = gm.hasAccess(g, p.getUniqueId(),
-					PermissionType.getPermission("PERMS"));
+			boolean canEdit = gm.hasAccess(g, p.getUniqueId(), PermissionType.getPermission("PERMS"))
+					|| g.getOwner().equals(p.getUniqueId());
 
 			if (hasPerm) {
 				is = yesStack();
@@ -170,8 +170,8 @@ public class PermissionManageGUI extends AbstractGroupGUI {
 					@Override
 					public void clicked(Player arg0) {
 						if (hasPerm == gp.hasPermission(pType, perm)) { // recheck
-							if (gm.hasAccess(g, p.getUniqueId(),
-									PermissionType.getPermission("PERMS"))) {
+							if (gm.hasAccess(g, p.getUniqueId(), PermissionType.getPermission("PERMS"))
+									|| g.getOwner().equals(p.getUniqueId())) {
 								NameLayerPlugin.log(Level.INFO, p.getName()
 										+ (hasPerm ? " removed " : " added ")
 										+ "the permission " + perm.getName()


### PR DESCRIPTION
Always allow Primary Owner to change group permissions even if their rank lacks the "PERMS" permission.

Fixes issue CivMC/Civ#148 

PS: Please make sure to test the code because I didn't as I don't have a dev env set up :<