### PR TITLE
Fix show next page

### DIFF
--- a/paper/src/main/java/vg/civcraft/mc/namelayer/gui/GUIGroupOverview.java
+++ b/paper/src/main/java/vg/civcraft/mc/namelayer/gui/GUIGroupOverview.java
@@ -109,14 +109,14 @@ public class GUIGroupOverview {
 			ci.setSlot(baCl, 45);
 		}
 		// next button
-		if ((45 * (currentPage + 1)) <= groups.size()) {
+		if ((45 * (currentPage + 1)) < groups.size()) {
 			ItemStack forward = new ItemStack(Material.ARROW);
 			ItemUtils.setDisplayName(forward, ChatColor.GOLD + "Go to next page");
 			Clickable forCl = new Clickable(forward) {
 
 				@Override
 				public void clicked(Player arg0) {
-					if ((45 * (currentPage + 1)) <= groups.size()) {
+					if ((45 * (currentPage + 1)) < groups.size()) {
 						currentPage++;
 					}
 					showScreen();

--- a/paper/src/main/java/vg/civcraft/mc/namelayer/gui/MainGroupGUI.java
+++ b/paper/src/main/java/vg/civcraft/mc/namelayer/gui/MainGroupGUI.java
@@ -108,14 +108,14 @@ public class MainGroupGUI extends AbstractGroupGUI {
 			ci.setSlot(baCl, 45);
 		}
 		// next button
-		if ((45 * (currentPage + 1)) <= clicks.size()) {
+		if ((36 * (currentPage + 1)) < clicks.size()) {
 			ItemStack forward = new ItemStack(Material.ARROW);
 			ItemUtils.setDisplayName(forward, ChatColor.GOLD + "Go to next page");
 			Clickable forCl = new Clickable(forward) {
 
 				@Override
 				public void clicked(Player arg0) {
-					if ((45 * (currentPage + 1)) <= clicks.size()) {
+					if ((36 * (currentPage + 1)) < clicks.size()) {
 						currentPage++;
 					}
 					showScreen();


### PR DESCRIPTION
This should fix the following two issues i think?
1) 'go to next page' button available in group & group member overviews even though there is no more groups/members to be shown when the current page is fully filled with the last groups/members
- caused by <= operator, should be <

2) 'go to next page' button not available in group member overview (mainGroupGUI) even though not all members have been shown yet when the total amount of members is within certain ranges (37-44, etc.)
- caused by assumption that 5 rows (45 slots) of members are shown per page when it's 4 rows