### PR TITLE
Fix show next page part 2

### DIFF
--- a/paper/src/main/java/vg/civcraft/mc/namelayer/gui/MainGroupGUI.java
+++ b/paper/src/main/java/vg/civcraft/mc/namelayer/gui/MainGroupGUI.java
@@ -81,11 +81,6 @@ public class MainGroupGUI extends AbstractGroupGUI {
 		}
 		ClickableInventory ci = new ClickableInventory(54, g.getName());
 		final List<Clickable> clicks = constructClickables();
-		if (clicks.size() < 45 * currentPage) {
-			// would show an empty page, so go to previous
-			currentPage--;
-			showScreen();
-		}
 		// fill gui
 		for (int i = 36 * currentPage; i < 36 * (currentPage + 1)
 				&& i < clicks.size(); i++) {


### PR DESCRIPTION
My previous pr was missing this and did thus not fully solve the issue with not being able to see all group member pages:
Currently when loading a page it first checks whether the page would be empty or not - but it contains the same issue as in the previous pr: it assumes 5 rows of member slots instead of the actual 4 so uses the incorrect nr of 45 instead of 36, plus wrong operator. Thus atm it can incorrectly calculate that the current page is empty and reload the previous page.
Either:
- this check should be removed as it seems unnecessary?
- or < 45 should be changed to <= 36