### PR TITLE
Fix show previous page

### DIFF
--- a/paper/src/main/java/vg/civcraft/mc/namelayer/gui/MainGroupGUI.java
+++ b/paper/src/main/java/vg/civcraft/mc/namelayer/gui/MainGroupGUI.java
@@ -126,7 +126,9 @@ public class MainGroupGUI extends AbstractGroupGUI {
 
 		// options
 
-		ci.setSlot(getSuperMenuClickable(), 45);
+		if (currentPage == 0) {
+			ci.setSlot(getSuperMenuClickable(), 45);
+		}
 		ci.setSlot(createInheritedMemberToggle(), 46);
 		ci.setSlot(createInviteToggle(), 47);
 		ci.setSlot(setupMemberTypeToggle(PlayerType.MEMBERS, showMembers), 48);


### PR DESCRIPTION
'Go to previous page' button (lines 95-109) is set to slot 45 when currentPage > 0, conflicting with 'Return to overview' which is afterwards set to slot 45 in all cases thus the previous page button never shows up. Id guess intended was for the latter to only be available on the first page?