### PR TITLE
Lock "PERMS" permission for OWNERS

### DIFF
--- a/paper/src/main/java/vg/civcraft/mc/namelayer/command/commands/ModifyPermissions.java
+++ b/paper/src/main/java/vg/civcraft/mc/namelayer/command/commands/ModifyPermissions.java
@@ -66,8 +66,8 @@ public class ModifyPermissions extends BaseCommandMiddle {
 		}
 		GroupPermission gPerm = gm.getPermissionforGroup(g);
 
-		if (playerType == PlayerType.NOT_BLACKLISTED && !pType.getCanBeBlacklisted()) {
-			sender.sendMessage(ChatColor.RED + "You can not change this permission for non-blacklisted players.");
+		if (pType.getIsLocked(playerType)) {
+			sender.sendMessage(ChatColor.RED + "You can not change this permission for %s".formatted(PlayerType.getNiceRankName(playerType)));
 			return;
 		}
 

--- a/paper/src/main/java/vg/civcraft/mc/namelayer/gui/PermissionManageGUI.java
+++ b/paper/src/main/java/vg/civcraft/mc/namelayer/gui/PermissionManageGUI.java
@@ -152,7 +152,7 @@ public class PermissionManageGUI extends AbstractGroupGUI {
 					}
 				}
 			}
-			if (pType == PlayerType.NOT_BLACKLISTED && !perm.getCanBeBlacklisted()) {
+			if (!perm.getIsLocked(pType)) {
 				canEdit = false;
 
 				ItemUtils.addLore(

--- a/paper/src/main/java/vg/civcraft/mc/namelayer/gui/PermissionManageGUI.java
+++ b/paper/src/main/java/vg/civcraft/mc/namelayer/gui/PermissionManageGUI.java
@@ -152,7 +152,7 @@ public class PermissionManageGUI extends AbstractGroupGUI {
 					}
 				}
 			}
-			if (!perm.getIsLocked(pType)) {
+			if (perm.getIsLocked(pType)) {
 				canEdit = false;
 
 				ItemUtils.addLore(

--- a/paper/src/main/java/vg/civcraft/mc/namelayer/permission/PermissionType.java
+++ b/paper/src/main/java/vg/civcraft/mc/namelayer/permission/PermissionType.java
@@ -109,7 +109,7 @@ public class PermissionType {
 		//allows to add/remove owners
 		registerPermission("OWNER", new ArrayList<>(owner), "Allows inviting new owners and removing existing owners");
 		//allows to modify the permissions for different permissions groups
-		registerPermission("PERMS", new ArrayList<>(owner), "Allows modifying permissions for this group");
+		registerPermission("PERMS", new ArrayList<>(owner), "Allows modifying permissions for this group", Map.ofEntries(Map.entry("PERMS", PlayerType.OWNER)));
 		//allows deleting the group
 		registerPermission("DELETE", new ArrayList<>(owner), "Allows deleting this group");
 		//allows merging the group with another one


### PR DESCRIPTION
If this permission can be toggled for OWNER, primary owner is almost useless because any other owner can steal the group by enabling this perm for admins, demoting themselves to admins and disabling the perm for owners. And disabling it for owners preemptively locks the ability to change the group's perms. Locking the permission for owners will prevent this.